### PR TITLE
Adding derived subscriptions using signals

### DIFF
--- a/test/greenpowermonitor/re_om_subs_test.cljs
+++ b/test/greenpowermonitor/re_om_subs_test.cljs
@@ -39,12 +39,29 @@
     [:div#re-om-test
      "ok"])))
 
+(defn- derived-sub-view [data owner]
+  (om/component
+   (html
+    [:div#re-om-test
+     (let [value (sut/subscribe [::derived-subscription 4] owner)]
+       value)])))
+
+(defn- complex-sub-view [data owner]
+  (om/component
+   (html
+    [:div#re-om-test
+     (let [value-1 (sut/subscribe [::final-subscription-1 "subs-1"] owner)
+           value-2 (sut/subscribe [::final-subscription-2 "subs-2"] owner)]
+       (str value-1 "_" value-2))])))
+
 (defn- mount-component-on-root! []
   (om/root
    (fn [data owner]
      (om/component
       (html
        (case (:view data)
+         :complex-subscription (om/build complex-sub-view {})
+         :derived-subscription (om/build derived-sub-view {})
          :no-subscription (om/build no-sub-view {})
          (om/build sub-view {})))))
    sut/*db*
@@ -141,5 +158,186 @@
              (swap! sut/*db* assoc :some-key :should-not-rerun-sub)
 
              (is (= 3 @times-executed))
+
+             (done)))))
+
+(deftest derived-subscriptions-work
+  (async done
+         (let [times-executed (atom 0)
+               times-derived-executed (atom 0)
+               external-db (atom {:view :derived-subscription
+                                  :source-value -2})]
+           (sut/register-sub!
+            ::test-subscription
+            (fn [db args]
+              (swap! times-executed inc)
+              (:source-value db)))
+
+           (sut/register-sub!
+            ::derived-subscription
+            :<- [::test-subscription]
+            (fn [value args]
+              (swap! times-derived-executed inc)
+              (+ value (first args))))
+
+           (go
+             (sut/dispatch! [::sut/init-db external-db])
+             (mount-component-on-root!)
+
+             (<! (core.async/timeout 300))
+
+             (is (= "2"
+                    (inner-html fixtures/c "#re-om-test")))
+
+             (swap! sut/*db* assoc :source-value 3)
+
+             (<! (core.async/timeout 300))
+
+             (is (= "7"
+                    (inner-html fixtures/c "#re-om-test")))
+
+             (swap! sut/*db* assoc :some-key :should-not-rerun-derived-sub)
+             (swap! sut/*db* assoc :some-key :also-should-not)
+             (swap! sut/*db* assoc :some-key :same-thing)
+
+             (is (= 5 @times-executed))
+             (is (= 2 @times-derived-executed))
+
+             (done)))))
+
+(deftest derived-subscriptions-work-with-multiple-levels
+  (async done
+         (let [times-executed (atom 0)
+               times-middle-executed (atom 0)
+               times-final-1-executed (atom 0)
+               times-final-2-executed (atom 0)
+               external-db (atom {:view :complex-subscription
+                                  :source-string "original"})]
+           (sut/register-sub!
+            ::test-subscription
+            (fn [db args]
+              (swap! times-executed inc)
+              (:source-string db)))
+
+           (sut/register-sub!
+            ::middle-subscription
+            :<- [::test-subscription]
+            (fn [s args]
+              (swap! times-middle-executed inc)
+              (str s "-middle")))
+
+           (sut/register-sub!
+            ::final-subscription-1
+            :<- [::middle-subscription]
+            (fn [s args]
+              (swap! times-final-1-executed inc)
+              (str s "-sub-1")))
+
+           (sut/register-sub!
+            ::final-subscription-2
+            :<- [::middle-subscription]
+            (fn [s args]
+              (swap! times-final-2-executed inc)
+              (str s "-sub-2")))
+
+           (go
+             (sut/dispatch! [::sut/init-db external-db])
+             (mount-component-on-root!)
+
+             (<! (core.async/timeout 300))
+
+             (is (= "original-middle-sub-1_original-middle-sub-2"
+                    (inner-html fixtures/c "#re-om-test")))
+
+             (swap! sut/*db* assoc :source-string "changed")
+
+             (<! (core.async/timeout 300))
+
+             (is (= "changed-middle-sub-1_changed-middle-sub-2"
+                    (inner-html fixtures/c "#re-om-test")))
+
+             (swap! sut/*db* assoc :some-key :should-not-rerun-derived-sub)
+             (swap! sut/*db* assoc :some-key :also-should-not)
+             (swap! sut/*db* assoc :some-key :same-thing)
+
+             (is (= 5 @times-executed))
+             (is (= 2 @times-middle-executed))
+             (is (= 2 @times-final-1-executed))
+             (is (= 2 @times-final-2-executed))
+
+             (done)))))
+
+(deftest derived-subscriptions-dedup-with-multiple-levels
+  (async done
+         (let [equal-strings "Strings are equal"
+               diff-strings "Strings are different"
+               times-source-1-executed (atom 0)
+               times-source-2-executed (atom 0)
+               times-middle-executed (atom 0)
+               times-final-executed (atom 0)
+               external-db (atom {:view :derived-subscription
+                                  :source-value-1 "source-1"
+                                  :source-value-2 "source-2"})]
+           (sut/register-sub!
+            ::source-subscription-1
+            (fn [db args]
+              (swap! times-source-1-executed inc)
+              (:source-value-1 db)))
+
+           (sut/register-sub!
+            ::source-subscription-2
+            (fn [db args]
+              (swap! times-source-2-executed inc)
+              (:source-value-2 db)))
+
+           (sut/register-sub!
+            ::middle-subscription
+            :<- [::source-subscription-1]
+            :<- [::source-subscription-2]
+            (fn [[s1 s2] args]
+              (swap! times-middle-executed inc)
+              (= s1 s2)))
+
+           (sut/register-sub!
+            ::derived-subscription
+            :<- [::middle-subscription]
+            (fn [s args]
+              (swap! times-final-executed inc)
+              (if s
+                equal-strings
+                diff-strings)))
+
+           (go
+             (sut/dispatch! [::sut/init-db external-db])
+             (mount-component-on-root!)
+
+             (<! (core.async/timeout 300))
+
+             (is (= diff-strings
+                    (inner-html fixtures/c "#re-om-test")))
+
+             (swap! sut/*db* assoc :source-value-1 "source-2")
+
+             (<! (core.async/timeout 300))
+
+             (is (= equal-strings
+                    (inner-html fixtures/c "#re-om-test")))
+
+             (swap! sut/*db* merge {:source-value-1 "source-4"
+                                    :source-value-2 "source-4"})
+
+             (<! (core.async/timeout 300))
+
+             (is (= equal-strings
+                    (inner-html fixtures/c "#re-om-test")))
+
+             (swap! sut/*db* assoc :some-key :should-not-rerun-derived-sub)
+             (swap! sut/*db* assoc :some-key :also-should-not)
+             (swap! sut/*db* assoc :some-key :same-thing)
+
+             (is (= 6 @times-source-1-executed))
+             (is (= 6 @times-source-2-executed))
+             (is (= 3 @times-middle-executed))
+             (is (= 2 @times-final-executed))
 
              (done)))))

--- a/test/greenpowermonitor/re_om_subs_test.cljs
+++ b/test/greenpowermonitor/re_om_subs_test.cljs
@@ -13,10 +13,6 @@
 (defn my-sub-fn [db args]
   :result)
 
-(deftest registering-a-subscription
-  (sut/register-sub! ::my-sub my-sub-fn)
-  (is (= my-sub-fn (sut/get-handler :subs ::my-sub))))
-
 (deftest when-subscription-does-not-exist-throw-an-exception
   (try
     (sut/subscribe [::does-not-exist] nil)


### PR DESCRIPTION
Basically implementing the same logic as re-frame has to optimize subscriptions so they don't get recomputed on every db change, also allowing for the dedup of signals