### PR TITLE
Rewrite error message

### DIFF
--- a/src/greenpowermonitor/re_om.cljs
+++ b/src/greenpowermonitor/re_om.cljs
@@ -18,7 +18,7 @@
   (if-let [handler (get-in @subs-handlers [:subs id])]
     handler
     (throw (ex-info
-            "Not registered handler!!"
+            "No handler registered!!"
             {:cause :no-handler-registered
              :id id
              :handler-type :subs}))))


### PR DESCRIPTION
The error `:cause` and the error message now are in sync